### PR TITLE
outdated group:food_water_glass

### DIFF
--- a/crafts/craftitems.lua
+++ b/crafts/craftitems.lua
@@ -164,7 +164,7 @@ cg.food_vanilla = "group:food_vanilla"
 cg.food_vegan = "group:food_vegan"
 cg.food_vegan_meat = "group:food_vegan_meat"
 cg.food_vegan_sandwich = "group:food_vegan_sandwich"
-cg.food_water_glass = "group:food_water_glass"
+cg.food_water_glass = "group:food_glass_water"
 cg.food_wheat = "group:food_wheat"
 cg.food_wine = "group:food_wine"
 


### PR DESCRIPTION
farming [changed ](https://codeberg.org/tenplus1/farming/commit/d4b0b02fc4ab5f43f846d9657bb794a9ba4df8b6)from "group:food_water_glass" to "group:food_glass_water" 8 months ago.